### PR TITLE
Make recipe cross-compile capable

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
-  build:
+  host:
     - python
     - pip
   run:


### PR DESCRIPTION
Change from build to host as recommended when using conda build 3.